### PR TITLE
修复下载过程中出错时，升级窗口按钮无法点击的问题

### DIFF
--- a/flutter_app_upgrade/lib/src/simple_app_upgrade.dart
+++ b/flutter_app_upgrade/lib/src/simple_app_upgrade.dart
@@ -349,9 +349,11 @@ class _SimpleAppUpgradeWidget extends State<SimpleAppUpgradeWidget> {
         }
       });
     } catch (e) {
-      print('$e');
-      _downloadProgress = 0;
+      print('simple app upgrade error >> $e');
       _updateDownloadStatus(DownloadStatus.error,error: e);
+      setState(() {
+        _downloadProgress = 0;
+      });
     }
   }
 


### PR DESCRIPTION
下载过程中，如果出现如网络不通等错误，导致下载中断，虽然downloadStatusChange可以获取到错误，但是升级窗口因为有wave动画覆盖，按钮无法响应用户点击。